### PR TITLE
Add some tests and extras

### DIFF
--- a/analytic_diffuse/__init__.py
+++ b/analytic_diffuse/__init__.py
@@ -19,7 +19,7 @@ def get_model(name):
         Callable function.
     """
     if name not in available_models:
-        raise ValueError("Model {} is not available".format(name))
+        raise ValueError(f"Model {name} is not available")
 
     return getattr(models, name)
 
@@ -39,6 +39,6 @@ def get_solution(name):
         Callable function.
     """
     if name not in available_models:
-        raise ValueError("Solution {} is not available".format(name))
+        raise ValueError(f"Solution {name} is not available")
 
     return getattr(solutions, name)

--- a/analytic_diffuse/__init__.py
+++ b/analytic_diffuse/__init__.py
@@ -1,7 +1,7 @@
 from . import models
 from . import solutions
 
-from .models import _funcnames as available_models
+from .models import sky_models as available_models
 
 
 def get_model(name):

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -49,8 +49,6 @@ def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}
     else:
         res = [quad(integrand, 0, 1, args=(uu), points=p, **quad_kwargs)[0] for uu, p in zip(u, points)]
 
-    print(scalar, res)
-
     if scalar:
         return res[0]
     else:

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -1,26 +1,57 @@
-from scipy.integrate import quad
+from scipy import integrate
 import numpy as np
 from . import models
-from scipy.special import j0
+from scipy.special import j0, jn_zeros
+import mpmath as mp
 
-
-def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}, *args, **kwargs):
+def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}, high_precision=False, use_points=False, *args, **kwargs):
     if callable(model):
         assert model.__name__ in models._funcnames
     else:
         model = getattr(models, model)
 
-    def integrand(r, uu):
-        phi = np.arcsin(r)  # using phi here because that's what we use in the paper, though in models.py it's theta
-        return 2*np.pi * r * model(None, phi, *args, **kwargs) / np.cos(phi) * j0(2*np.pi* uu *r)
+    if model.__name__ in models._projected_funcs:
+        # using phi here because that's what we use in the paper, though in models.py it's theta
+        def integrand(r, uu):
+            if high_precision:
+                bj0 = mp.j0(2 * np.pi * uu * r) if high_precision else j0(2 * np.pi * uu * r)
+                phi = mp.asin(r)
+            else:
+                bj0 = j0(2 * np.pi * uu * r)
+                phi = np.arcsin(r)
+
+            return 2*np.pi * r * model(None, phi, projected=True, *args, **kwargs) * bj0
+    else:
+        def integrand(r, uu):
+            if high_precision:
+                phi = mp.asin(r)
+                n = mp.cos(phi)
+                bj0 = mp.j0(2 * np.pi * uu * r)
+            else:
+                phi = np.arcsin(r)
+                bj0 = j0(2 * np.pi * uu * r)
+                n = np.cos(phi)
+
+            return 2*np.pi * r * model(None, phi, *args, **kwargs) / n * bj0
 
     scalar = np.isscalar(u)
     u = np.atleast_1d(u)
-    res = [quad(integrand, 0, 1, args=(uu), **quad_kwargs) for uu in u]
 
-    res, info = [r[0] for r in res], [r[1:] for r in res]
+    if use_points:
+        points = [jn_zeros(0, int(2*uu))/(2*np.pi*uu) if uu > 5 else [] for uu in u]
+        points = [p[p<1].tolist() if len(p) else [] for p in points]
+    else:
+        points = [[]]*len(u)
+
+    quad = mp.quad if high_precision else integrate.quad
+    if high_precision:
+        res = [float(mp.quad(lambda r: integrand(r, uu), [0] + p + [1], **quad_kwargs)) for uu, p in zip(u, points)]
+    else:
+        res = [quad(integrand, 0, 1, args=(uu), points=p, **quad_kwargs)[0] for uu, p in zip(u, points)]
+
+    print(scalar, res)
 
     if scalar:
-        return res[0], info[0]
+        return res[0]
     else:
-        return res, info
+        return res

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -3,51 +3,96 @@ import numpy as np
 from . import models
 from scipy.special import j0, jn_zeros
 import mpmath as mp
+from typing import Optional
 
-def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}, high_precision=False, use_points=False, *args, **kwargs):
+
+def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs: Optional[dict]=None,
+                  high_precision: bool=False, use_points: bool=False, *args, **kwargs):
+    """
+    Perform transform to determine visibility solutions for circularly symmetric
+    sky models.
+
+    Performs the integral
+
+    .. math:: V(u) = \int_0^1 r I'(r) J_0(2\pi u r) dr,
+
+    where ``r`` is ``sin(za)`` and ``I'(r)`` is the projected sky model, ``I(r)/cos(za)``.
+
+    Parameters
+    ----------
+    model : callable or str
+        The sky model to integrate. Must be a model decorated with `circsym` (whether
+        user-defined or built-in). If a string, just the function name.
+    u : float or ndarray
+        The magnitude(s) of the baseline vectors at which to evaluate the visibility,
+        in units of wavelengths.
+    quad_kwargs : dict, optional
+        Keyword arguments to pass to the `quad` function to control its behaviour.
+        Note that if ``high_precision`` is True, the `quad` function is from mpmath,
+        otherwise it is from scipy.
+    high_precision : bool, optional
+        Whether to use the high-precision library mpmath for evaluating the model and
+        the integral.
+    use_points : bool, optional
+        Whether to specify zeros of the Bessel function to pass to the quad routine, to
+        aid evaluation of highly-oscillatory integrals.
+    args :
+        Extra arguments passed to the model
+    kwargs :
+        Extra arguments passed to the model
+
+    Returns
+    -------
+    float or ndarray
+        The real visibility solution at the given baseline magnitudes, ``u``.
+        Will be a scalar float if u is a float, ndarray otherwise.
+
+    Notes
+    -----
+    This function is valid for any circularly symmetric sky model (whether defined in
+    projected co-ordinates or not), even though analytically it is not the easiest way
+    to integrate any particular model.
+    """
+    quad_kwargs = quad_kwargs or {}
     if callable(model):
-        assert model.__name__ in models._funcnames
+        assert model.__name__ in models.circular_models
     else:
+        assert model in models.circular_models
         model = getattr(models, model)
 
-    if model.__name__ in models._projected_funcs:
-        # using phi here because that's what we use in the paper, though in models.py it's theta
-        def integrand(r, uu):
-            if high_precision:
-                bj0 = mp.j0(2 * np.pi * uu * r) if high_precision else j0(2 * np.pi * uu * r)
-                phi = mp.asin(r)
-            else:
-                bj0 = j0(2 * np.pi * uu * r)
-                phi = np.arcsin(r)
-
-            return 2*np.pi * r * model(None, phi, projected=True, *args, **kwargs) * bj0
+    # Define functions depending on whether using high precision or not.
+    # Faster if defined outside the integrand function.
+    if high_precision:
+        asin = mp.asin
+        J0 = mp.j0
+        cos = mp.cos
     else:
-        def integrand(r, uu):
-            if high_precision:
-                phi = mp.asin(r)
-                n = mp.cos(phi)
-                bj0 = mp.j0(2 * np.pi * uu * r)
-            else:
-                phi = np.arcsin(r)
-                bj0 = j0(2 * np.pi * uu * r)
-                n = np.cos(phi)
+        asin = np.arcsin
+        J0 = j0
+        cos = np.cos
 
-            return 2*np.pi * r * model(None, phi, *args, **kwargs) / n * bj0
+    tau = 2 * np.pi
+
+    # Define the integrand. We get some speed up in models that are defined in projected
+    # co-ordinates by not multiplying then dividing by cos(za).
+    def integrand(r, uu):
+        return tau * r * model(None, asin(r), projected=True, *args, **kwargs) * J0(tau * uu * r)
 
     scalar = np.isscalar(u)
     u = np.atleast_1d(u)
 
+    # If the user wants to specify integration points, get the list of zeros of the
+    # Bessel function, out to r=1. Only use the points if there's more than 5.
     if use_points:
-        points = [jn_zeros(0, int(2*uu))/(2*np.pi*uu) if uu > 5 else [] for uu in u]
-        points = [p[p<1].tolist() if len(p) else [] for p in points]
+        points = [jn_zeros(0, int(2*uu))/(tau*uu) if uu > 5 else [] for uu in u]
+        points = [p[p < 1].tolist() if len(p) else [] for p in points]
     else:
         points = [[]]*len(u)
 
-    quad = mp.quad if high_precision else integrate.quad
     if high_precision:
         res = [float(mp.quad(lambda r: integrand(r, uu), [0] + p + [1], **quad_kwargs)) for uu, p in zip(u, points)]
     else:
-        res = [quad(integrand, 0, 1, args=(uu), points=p, **quad_kwargs)[0] for uu, p in zip(u, points)]
+        res = [integrate.quad(integrand, 0, 1, args=(uu,), points=p, **quad_kwargs)[0] for uu, p in zip(u, points)]
 
     if scalar:
         return res[0]

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -1,0 +1,2 @@
+from scipy import quad
+

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -1,2 +1,18 @@
-from scipy import quad
+from scipy.integrate import quad
+import numpy as np
+from . import models
+from scipy.special import j0
 
+
+def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}, *args, **kwargs):
+    if callable(model):
+        assert model.__name__ in models._funcnames
+    else:
+        model = getattr(models, model)
+
+    def integrand(r, uu):
+        phi = np.arcsin(r)  # using phi here because that's what we use in the paper, though in models.py it's theta
+        return 2*np.pi * r * model(None, phi, *args, **kwargs) / np.cos(phi) * j0(2*np.pi* uu *r)
+
+    res = [quad(integrand, 0, 1, args=(uu), **quad_kwargs) for uu in u]
+    return [r[0] for r in res], [r[1:] for r in res]

--- a/analytic_diffuse/integrators.py
+++ b/analytic_diffuse/integrators.py
@@ -14,5 +14,13 @@ def hankel_solver(model: [callable, str], u: [float, np.ndarray], quad_kwargs={}
         phi = np.arcsin(r)  # using phi here because that's what we use in the paper, though in models.py it's theta
         return 2*np.pi * r * model(None, phi, *args, **kwargs) / np.cos(phi) * j0(2*np.pi* uu *r)
 
+    scalar = np.isscalar(u)
+    u = np.atleast_1d(u)
     res = [quad(integrand, 0, 1, args=(uu), **quad_kwargs) for uu in u]
-    return [r[0] for r in res], [r[1:] for r in res]
+
+    res, info = [r[0] for r in res], [r[1:] for r in res]
+
+    if scalar:
+        return res[0], info[0]
+    else:
+        return res, info

--- a/analytic_diffuse/models.py
+++ b/analytic_diffuse/models.py
@@ -4,70 +4,94 @@ import numpy as np
 from functools import wraps
 import mpmath as mp
 
-_funcnames = []
-_projected_funcs = []
+sky_models = []
+_projected_models = []   # A list of models whose functions define projected models
+circular_models = []  # A list of models which are circularly symmetric.
 
-
-def checkinput(func):
+def sky_model(func):
     """Enforce input shapes and horizon cutoff."""
-    global _funcnames
+    sky_models.append(func.__name__)
 
-    _funcnames.append(func.__name__)
+    param_doc = """Parameters
+    ----------
+    az: float or ndarray of float
+        Azimuth in radians, shape (Npixels,)
+    za: float or ndarray of float
+        Zenith angle in radians, shape (Npixels,)"""
+
+    other_doc = """Other Parameters
+    ----------------
+    projected: bool, optional
+        Whether to return the projected sky model ``I / cos(za)``."""
+
+    func.__doc__ = func.__doc__.format(params=param_doc, other=other_doc)
+    func.__doc__ += """
+    Returns
+    -------
+    float or np.ndarray
+        The intensity of the sky model at the input co-ordinates. Same shape
+        as ``za``."""
+
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(az, za, *args, projected: bool=False, **kwargs):
         # Check validity of input shapes
-        phi = args[0]
         # Check whether input was scalar.
-        scalar = np.isscalar(args[1])
-
-        theta = args[1]
+        scalar = np.isscalar(za)
 
         if not scalar:
-            theta = np.array(theta)
-            if phi is not None:
-                phi = np.array(phi)
+            za = np.array(za)
+            if az is not None:
+                az = np.array(az)
 
-        if scalar and theta > np.pi/2:
+        if scalar and za > np.pi/2:
             return 0
 
-        if phi is not None and not scalar and phi.shape != theta.shape:
+        if not ((az is None or scalar) or az.shape == za.shape):
             raise ValueError(
-                "phi and theta must have the same shape: {}, {}".format(
-                    str(phi.shape), str(theta.shape)
+                "az and za must have the same shape: {}, {}".format(
+                    str(az.shape), str(za.shape)
                 )
             )
-        result = func(phi, theta, *args[2:], **kwargs)
+        result = func(az, za, *args, **kwargs)
 
         # Set pixels outside the horizon to zero.
         if not scalar:
-            result[theta > np.pi / 2] = 0
+            result[za > np.pi / 2] = 0
 
-        # If a scalar was passed in, return a scalar.
+        if func.__name__ in _projected_models and not projected:
+            try:
+                result *= np.cos(za)
+            except AttributeError:
+                result *= mp.cos(za)
+        elif func.__name__ not in _projected_models and projected:
+            try:
+                result /= np.cos(za)
+            except AttributeError:
+                result /= mp.cos(za)
+
+            # If a scalar was passed in, return a scalar.
         return result
     return wrapper
 
 
 def projected(func):
-    """Enforce input shapes and horizon cutoff."""
-    global _projected_funcs
-
-    _projected_funcs.append(func.__name__)
+    """Mark a model as defining itself in projected co-ordinates."""
+    _projected_models.append(func.__name__)
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        projected = kwargs.pop('projected', False)
-
-        result = func(*args, **kwargs)
-
-        if not projected:
-            try:
-                result *= np.cos(args[1])
-            except AttributeError:
-                result *= mp.cos(args[1])
-
-        return result
+        return func(*args, **kwargs)
     return wrapper
 
+
+def circsym(func):
+    """Mark a model as defining itself in projected co-ordinates."""
+    circular_models.append(func.__name__)
+
+    @wraps(func)
+    def wrapper(az, za, *args, **kwargs):
+        return func(None, za, *args, **kwargs)
+    return wrapper
 
 def _angle_to_lmn(phi, theta):
     phi, theta = np.atleast_1d(phi), np.atleast_1d(theta)
@@ -78,104 +102,100 @@ def _angle_to_lmn(phi, theta):
     return lmn
 
 
-@checkinput
-def monopole(phi, theta):
+@circsym
+@sky_model
+def monopole(az: [None, float, np.ndarray], za: [float, np.ndarray]):
     """
     Trivially, 1 everywhere.
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
+
+    {other}
     """
-    return np.ones_like(theta)
+    return np.ones_like(za)
 
 
+@circsym
 @projected
-@checkinput
-def cosza(phi, theta):
+@sky_model
+def cosza(az: [None, float, np.ndarray], za: [float, np.ndarray]):
     """
     Cosine of zenith angle.
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
+
+    {other}
     """
-    return np.ones_like(theta)
+    return np.ones_like(za)
 
 
+@circsym
 @projected
-@checkinput
-def polydome(phi, theta, n=2):
+@sky_model
+def polydome(az: [None, float, np.ndarray], za: [float, np.ndarray], n: int=2):
     """
     Polynomial function of zenith, weighted by cos(theta).
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
     n: int
         Order of polynomial (Default of 2)
         Must be even.
+
+    {other}
     """
-    if n % 2 != 0:
+    if n % 2:
         raise ValueError("Polynomial order must be even.")
     try:
-        return 1 - np.sin(theta) ** n
+        return 1 - np.sin(za) ** n
     except AttributeError:
-        return 1 - mp.sin(theta) ** n
+        return 1 - mp.sin(za) ** n
 
+@circsym
 @projected
-@checkinput
-def projgauss(phi, theta, a):
+@sky_model
+def projgauss(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float):
     """
     Gaussian weighted by cos(theta).
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
     a: float
         Gaussian width parameter.
+
+    {other}
+
+    Notes
+    -----
+    If called with `projected=True`, output is very similar to :func:`gauss` with
+    `projected=False`.
     """
     try:
-        return np.exp(-np.sin(theta)**2 / a**2)
+        return np.exp(-np.sin(za)**2 / a**2)
     except AttributeError:
-        return mp.exp(-mp.sin(theta) ** 2 / a ** 2)
+        return mp.exp(-mp.sin(za) ** 2 / a ** 2)
 
-@checkinput
-def gauss(phi, theta, a, el0vec=None):
+
+@circsym
+@sky_model
+def gauss(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float, el0vec: [None, np.ndarray]=None):
     """
     Gaussian, and off-zenith Gaussian.
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
     a: float
         Gaussian width parameter.
     el0vec: ndarray of float
         Cartesian vector describing lmn displacement of Gaussian center, shape (3,).
+
+    {other}
     """
-    if phi is None:
-        phi = np.zeros_like(theta)
+    if az is None:
+        az = np.zeros_like(za)
 
     if el0vec is None:
         el0vec = np.array([0, 0, 0])
 
     sigsq = a**2 / (2 * np.pi)
-    lmn = _angle_to_lmn(phi, theta)
+    lmn = _angle_to_lmn(az, za)
     disp = (lmn - el0vec)[:, :2]  # Only l and m
     ang = np.linalg.norm(disp, axis=1)
     try:
@@ -184,35 +204,32 @@ def gauss(phi, theta, a, el0vec=None):
         return mp.exp(-ang ** 2 / (2 * sigsq))
 
 
-@checkinput
-def xysincs(phi, theta, a, xi=0.0):
+@sky_model
+def xysincs(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float, xi: float=0.0):
     """
     Crossed sinc functions in l,m coordinates.
 
     Defined by:
         I(x,y) = sinc(ax) sinc(ay) cos(1 - x^2 - y^2), for |x| and |y| < 1/sqrt(2)
-               = 0, otherwise
+        = 0, otherwise
     where (x,y) is rotated from (l,m) by an angle xi.
 
-    Parameters
-    ----------
-    phi: ndarray of float
-        Azimuth in radians, shape (Npixels,)
-    theta: ndarray of float
-        Zenith angle in radians, shape (Npixels,)
+    {params}
     a: float
         Sinc parameter, giving width of the "box" in uv space.
         box width in UV is a/(2 pi)
     xi: float
         Rotation of (x,y) coordinates from (l,m) in radians.
+
+    {other}
     """
     cx, sx = np.cos(xi), np.sin(xi)
     rot = np.array([[cx, sx, 0], [-sx, cx, 0], [0, 0, 1]])
 
-    lmn = _angle_to_lmn(phi, theta)
+    lmn = _angle_to_lmn(az, za)
     xyvecs = np.dot(lmn, rot)
 
-    result = np.sinc(a * xyvecs[:, 0] / np.pi) * np.sinc(a * xyvecs[:, 1] / np.pi) * np.cos(theta)
+    result = np.sinc(a * xyvecs[:, 0] / np.pi) * np.sinc(a * xyvecs[:, 1] / np.pi) * np.cos(za)
     outside = np.where((np.abs(xyvecs[:, 0]) > 1 / np.sqrt(2))
                        | (np.abs(xyvecs[:, 1]) > 1 / np.sqrt(2)))
     result[outside] = 0.0

--- a/analytic_diffuse/models.py
+++ b/analytic_diffuse/models.py
@@ -15,16 +15,27 @@ def checkinput(func):
     def wrapper(*args, **kwargs):
         # Check validity of input shapes
         phi = args[0]
-        theta = args[1]
-        if theta and phi.shape != theta.shape:
+        # Check whether input was scalar.
+        scalar = np.isscalar(args[1])
+        theta = np.atleast_1d(args[1])
+        if phi is not None:
+            phi = np.atleast_1d(phi)
+
+
+        if phi is not None and phi.shape != theta.shape:
             raise ValueError(
                 "phi and theta must have the same shape: {}, {}".format(
                     str(phi.shape), str(theta.shape)
                 )
             )
-        result = func(*args, **kwargs)
+        result = func(phi, theta, *args[2:], **kwargs)
         # Set pixels outside the horizon to zero.
-        result[theta > np.pi / 2] *= 0
+        result[theta > np.pi / 2] = 0
+
+        # If a scalar was passed in, return a scalar.
+        if scalar:
+            return result[0]
+
         return result
     return wrapper
 

--- a/analytic_diffuse/models.py
+++ b/analytic_diffuse/models.py
@@ -16,7 +16,7 @@ def checkinput(func):
         # Check validity of input shapes
         phi = args[0]
         theta = args[1]
-        if not phi.shape == theta.shape:
+        if theta and phi.shape != theta.shape:
             raise ValueError(
                 "phi and theta must have the same shape: {}, {}".format(
                     str(phi.shape), str(theta.shape)
@@ -50,7 +50,7 @@ def monopole(phi, theta):
     theta: ndarray of float
         Zenith angle in radians, shape (Npixels,)
     """
-    return np.ones_like(phi)
+    return np.ones_like(theta)
 
 
 @checkinput
@@ -83,7 +83,7 @@ def polydome(phi, theta, n=2):
         Order of polynomial (Default of 2)
         Must be even.
     """
-    if not n % 2 == 0:
+    if n % 2 != 0:
         raise ValueError("Polynomial order must be even.")
     return np.cos(theta) * (1 - np.sin(theta)**n)
 
@@ -126,7 +126,7 @@ def gauss(phi, theta, a, el0vec=None):
 
     sigsq = a**2 / (2 * np.pi)
     lmn = _angle_to_lmn(phi, theta)
-    disp = (lmn - el0vec)[:, :2]  # Only l an m
+    disp = (lmn - el0vec)[:, :2]  # Only l and m
     ang = np.linalg.norm(disp, axis=1)
     return np.exp(-ang**2 / (2 * sigsq))
 

--- a/analytic_diffuse/models.py
+++ b/analytic_diffuse/models.py
@@ -85,13 +85,14 @@ def projected(func):
 
 
 def circsym(func):
-    """Mark a model as defining itself in projected co-ordinates."""
+    """Mark a model as circularly (azimuthally) symmetric."""
     circular_models.append(func.__name__)
 
     @wraps(func)
     def wrapper(az, za, *args, **kwargs):
         return func(None, za, *args, **kwargs)
     return wrapper
+
 
 def _angle_to_lmn(phi, theta):
     phi, theta = np.atleast_1d(phi), np.atleast_1d(theta)
@@ -175,6 +176,20 @@ def projgauss(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float):
 
 
 @circsym
+@sky_model
+def gauss_zenith(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float):
+    """
+    On-zenith Gaussian.
+
+    {params}
+    a: float
+        Gaussian width parameter.
+
+    {other}
+    """
+    return gauss(az, za, a)
+
+
 @sky_model
 def gauss(az: [None, float, np.ndarray], za: [float, np.ndarray], a: float, el0vec: [None, np.ndarray]=None):
     """

--- a/analytic_diffuse/solutions.py
+++ b/analytic_diffuse/solutions.py
@@ -4,7 +4,7 @@ import numpy as np
 import re
 from scipy.special import jv, factorial as fac, gammaincc, gamma, sici, hyp0f1
 from mpmath import hyp1f2
-
+import warnings
 
 @np.vectorize
 def vhyp1f2(a0, b0, b1, x):
@@ -28,11 +28,51 @@ def approx_hyp1f1(a, b, x, order=5):
 
 
 def vec_to_amp(vec):
-    vec = np.array(vec)
+    vec = np.atleast_1d(vec)
     assert vec.ndim in (1, 2)
     if vec.ndim == 2:
         assert vec.shape[1] <= 3
     return vec if vec.ndim == 1 else np.linalg.norm(vec, axis=1)
+
+
+def _perform_convergent_sum(fnc, u, order, chunk_order, atol, rtol, ret_cumsum, *args):
+    # Set the default order (100 if we're going to convergence, 30 otherwise)
+    order = order or (100 if chunk_order else 30)
+
+    # If we're not going to convergence, set chunk_order to order, so we just do the
+    # whole sum at once.
+    chunk_order = chunk_order or order
+
+    # Find out how many chunks we'll need (accounting for the bit at the end if
+    # they don't divide evenly)
+    n_chunks = order // chunk_order
+    if order % chunk_order:
+        n_chunks += 1
+
+    # Now set the actual order (>= original order)
+    order = n_chunks * chunk_order
+
+    sm = np.zeros(u.shape + (order, ))
+    u = u[..., None]
+
+    print('shapes: ', sm.shape, u.shape, sm[..., 0][..., None].shape)
+    counter = 0
+    while (
+        counter < 2 or not np.allclose(sm[..., counter-1], sm[..., counter-2], atol=atol, rtol=rtol)) and counter < order:
+        ks = np.arange(counter, counter + chunk_order)
+        sm[..., ks] = sm[..., counter-1][..., None] + np.cumsum(fnc(ks[None, ...], u, *args), axis=-1)
+        counter += chunk_order
+
+    if counter==order and order >= 2 and not np.allclose(sm[..., -1], sm[..., -2]):
+        warnings.warn("Desired tolerance not reached. Try setting order higher.")
+
+    # Restrict to actual calculated terms
+    sm = sm[..., :counter]
+
+    if ret_cumsum:
+        return sm.squeeze()
+    else:
+        return sm[..., -1].squeeze()
 
 
 def monopole(uvecs, order=3):
@@ -117,7 +157,7 @@ def polydome(uvecs, n=2):
     return res
 
 
-def projgauss(uvecs, a, order=30, usesmall=False, uselarge=False):
+def projgauss(uvecs, a, order=None, chunk_order=0, usesmall=False, uselarge=False, atol=1e-10, rtol=1e-8, ret_cumsum=False):
     """
     Solution for I(r) = exp(-r^2/2 a^2) * cos(r).
 
@@ -128,38 +168,55 @@ def projgauss(uvecs, a, order=30, usesmall=False, uselarge=False):
     a: float
         Gaussian width parameter.
     order: int
-        Expansion order.
+        If not `chunk_order`, the expansion order. Otherwise, this is the *maximum*
+        order of the expansion.
+    chunk_order: int
+        If non-zero, the expansion will be summed until convergence (or max order is
+        reached).
     usesmall: bool, optional
         Use small-a approximation, regardless of a.
         Default is False
     uselarge: bool, optional
         Use large-a approximation, regardless of a.
         Default is False
+    ret_cumsum : bool, optional
+        Whether to return the full cumulative sum of the expansion.
 
     Returns
     -------
     ndarray of complex
-        Visibilities, shape (Nbls,)
+        Visibilities, shape (Nbls,) (or (Nbls, nk) if `ret_cumsum` is True.)
     """
-    uamps = vec_to_amp(uvecs)
-    ks = np.arange(order)[None, :]
-    uamps = uamps[:, None]
+    u_amps = vec_to_amp(uvecs)
+
     if uselarge and usesmall:
         raise ValueError("Cannot use both small and large approximations at once")
-    if (a < 0.25 and not uselarge) or usesmall:
-        return np.pi * a**2 * (
-            np.exp(- np.pi**2 * a**2 * uamps[:,0]**2)
-            - np.sum(
-                (-1)**ks * (np.pi * uamps * a)**(2 * ks) * gammaincc(ks + 1, 1 / a**2)
-                / (fac(ks))**2, axis=1
-            )
+
+    usesmall = (a < 0.25 and not uselarge) or usesmall
+
+    if usesmall:
+        fnc = lambda ks, u: (
+            (-1) ** ks * (np.pi * u * a) ** (2 * ks) * gammaincc(ks + 1, 1 / a ** 2)
+            / (fac(ks)) ** 2
         )
     else:
-        return np.sum(np.pi * (-1)**ks * vhyp1f2(1 + ks, 1, 2 + ks, -np.pi**2 * uamps**2)
-                      / (a**(2 * ks) * fac(ks + 1)), axis=1)
+        fnc = lambda ks, u: (
+            np.pi * (-1)**ks * vhyp1f2(1 + ks, 1, 2 + ks, -np.pi**2 * u**2)
+            / (a**(2 * ks) * fac(ks + 1))
+        )
+
+    result = _perform_convergent_sum(fnc, u_amps, order, chunk_order, atol, rtol, ret_cumsum)
+    print(result.shape)
+
+    if usesmall:
+        exp = np.exp(-(np.pi * a * u_amps) ** 2)
+        if np.shape(result) != np.shape(exp):
+            exp = exp[..., None]
+        result = np.pi * a ** 2 * (exp - result).squeeze()
+    return result
 
 
-def gauss(uvecs, a, el0vec=None, order=10, usesmall=False, uselarge=False, hyporder=5):
+def gauss(uvecs, a, el0vec=None, order=None, chunk_order=0, usesmall=False, uselarge=False, hyporder=5, atol=1e-10, rtol=1e-8, ret_cumsum=False):
     """
     Solution for I(r) = exp(-r^2/2 a^2).
 
@@ -188,37 +245,40 @@ def gauss(uvecs, a, el0vec=None, order=10, usesmall=False, uselarge=False, hypor
     ndarray of complex
         Visibilities, shape (Nbls,)
     """
-    uamps = vec_to_amp(uvecs)
+    u_amps = vec_to_amp(uvecs)
+
     if el0vec is not None:
         udotel0 = np.dot(uvecs, el0vec)
         el0 = np.linalg.norm(el0vec)
-        el0_x = (udotel0.T / uamps).T
+        el0_x = (udotel0.T / u_amps).T
     else:
         udotel0 = 0.0
         el0_x = 0
         el0 = 0
 
-    u_in_series = np.sqrt(uamps**2 - el0**2 / a**4 + 2j * uamps * el0_x / a**2)
+    usesmall = (a < np.pi / 8 and not uselarge) or usesmall
 
-    ks = np.arange(order)
-    v = u_in_series
-    if (a < np.pi / 8 and not uselarge) or usesmall:
-        phasor = np.exp(-2 * np.pi * 1j * udotel0) * np.exp(-np.pi * a**2 * uamps**2)
-        hypterms = approx_hyp1f1(ks + 1, 3 / 2, -np.pi / a**2, order=hyporder)
-        ks = ks[None, :]
-        v = v[:, None]
-        hypterms = hypterms[None, :]
-        series = (np.sqrt(np.pi) * v * a)**(2 * ks) / gamma(ks + 1)
-        return (2 * np.pi * phasor * np.sum(series * hypterms, axis=1)).squeeze()
+    u_in_series = np.sqrt(u_amps**2 - el0**2 / a**4 + 2j * u_amps * el0_x / a**2)
+
+    if usesmall:
+        def fnc(ks, v):
+            hypterms = approx_hyp1f1(ks + 1, 3 / 2, -np.pi / a**2, order=hyporder)
+            hypterms = hypterms[None, :]
+            series = (np.sqrt(np.pi) * v * a)**(2 * ks) / gamma(ks + 1)
+            return series * hypterms
     else:
-        # order >= 40
-        phasor = np.exp(-np.pi * el0**2 / a**2)
-        v = v[:, None]
-        ks = ks[None, :]
-        hypterms = vhyp1f2(ks + 1, 1, ks + 3 / 2, -np.pi**2 * v**2)
-        ksum = np.sum((-1)**ks * (np.pi / a**2)**ks * hypterms / gamma(ks + 3 / 2), axis=1)
-        res = phasor * np.pi**(3 / 2) * ksum
-        return res.squeeze()
+        def fnc(ks, v):
+            hypterms = vhyp1f2(ks + 1, 1, ks + 3 / 2, -np.pi**2 * v**2)
+            return (-1)**ks * (np.pi / a**2)**ks * hypterms / gamma(ks + 3 / 2)
+
+    result = _perform_convergent_sum(fnc, u_in_series, order, chunk_order, atol, rtol, ret_cumsum)
+
+    if usesmall:
+        phasor = np.exp(-2 * np.pi * 1j * udotel0) * np.exp(-np.pi * a ** 2 * u_amps ** 2)
+        return (2 * np.pi * phasor * result).squeeze()
+    else:
+        phasor = np.exp(-np.pi * el0 ** 2 / a ** 2)
+        return (phasor * np.pi ** (3 / 2) * result).squeeze()
 
 
 def xysincs(uvecs, a, xi=0.0):

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -7,7 +7,9 @@ import numpy as np
     'model,kwargs',
     [('cosza', {}),
      ('polydome', {}),
-     ('projgauss', {'a': 0.01})]
+     ('projgauss', {'a': 0.01}),
+     ('projgauss', {'a': 2}),
+     ]
 )
 def test_against_hankel(model, kwargs):
     u = np.array([0.1, 1, 10, 100])

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -22,11 +22,14 @@ def test_against_hankel(model, kwargs):
     assert np.allclose(anl, num, rtol=1e-8)
 
 
-@pytest.mark.parametrize('a', (0.1, 0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
+@pytest.mark.parametrize('a', (0.1, 0.2, 0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
 def test_projgauss_mid_a(a):
-    u = np.array([0.1, 1, 10, 100])
+    if a < 0.25:
+        u = np.array([0.01, 0.1, 1]) / a
+    else:
+        u = np.array([0.01, 0.1, 1, 10, 100]) / a
 
-    anl = get_solution('projgauss')(u, a=a, order=1000, chunk_order=20, uselarge=True)
+    anl = get_solution('projgauss')(u, a=a, order=1000, chunk_order=20)
     num = integrators.hankel_solver('projgauss', u, quad_kwargs=dict(epsabs=0, limit=1000, epsrel=1e-8), use_points=True, a=a)
 
     assert np.allclose(anl, num, rtol=1e-8)

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -9,22 +9,24 @@ import numpy as np
      ('polydome', {}),
      ('projgauss', {'a': 0.01}),
      ('projgauss', {'a': 2}),
+     ('gauss', {'a': 0.01}),
+     ('gauss', {'a': 2})
      ]
 )
 def test_against_hankel(model, kwargs):
     u = np.array([0.1, 1, 10, 100])
 
     anl = get_solution(model)(u, **kwargs)
-    num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8),  **kwargs)[0]
+    num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8), **kwargs)
 
     assert np.allclose(anl, num, rtol=1e-8)
 
 
-@pytest.mark.parametrize('a', (0.2, 0.25, 0.5))
+@pytest.mark.parametrize('a', (0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
 def test_projgauss_mid_a(a):
     u = np.array([0.1, 1, 10, 100])
 
-    anl = get_solution('projgauss')(u, a=a)
-    num = integrators.hankel_solver('projgauss', u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8),  a=a)[0]
+    anl = get_solution('projgauss')(u, a=a, order=1000, chunk_order=20, uselarge=True)
+    num = integrators.hankel_solver('projgauss', u, quad_kwargs=dict(epsabs=0, limit=1000, epsrel=1e-8), use_points=True, a=a)
 
     assert np.allclose(anl, num, rtol=1e-8)

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -7,12 +7,12 @@ import numpy as np
     'model,kwargs',
     [('cosza', {}),
      ('polydome', {}),
-     ('projgauss', {'a':0.2})]
+     ('projgauss', {'a': 0.01})]
 )
 def test_against_hankel(model, kwargs):
-    u = np.array([0.1, 1])
+    u = np.array([0.1, 1, 10, 100])
 
     anl = get_solution(model)(u, **kwargs)
-    num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, epsrel=1e-8), **kwargs)[0]
+    num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8),  **kwargs)[0]
 
     assert np.allclose(anl, num, rtol=1e-8)

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -1,0 +1,18 @@
+from analytic_diffuse import integrators, models, get_model, get_solution
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    'model,kwargs',
+    [('cosza', {}),
+     ('polydome', {}),
+     ('projgauss', {'a':0.2})]
+)
+def test_against_hankel(model, kwargs):
+    u = np.array([0.1, 1])
+
+    anl = get_solution(model)(u, **kwargs)
+    num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, epsrel=1e-8), **kwargs)[0]
+
+    assert np.allclose(anl, num, rtol=1e-8)

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -9,8 +9,8 @@ import numpy as np
      ('polydome', {}),
      ('projgauss', {'a': 0.01}),
      ('projgauss', {'a': 2}),
-     ('gauss', {'a': 0.01}),
-     ('gauss', {'a': 2})
+     ('gauss_zenith', {'a': 0.01}),
+     ('gauss_zenith', {'a': 2})
      ]
 )
 def test_against_hankel(model, kwargs):
@@ -22,7 +22,7 @@ def test_against_hankel(model, kwargs):
     assert np.allclose(anl, num, rtol=1e-8)
 
 
-@pytest.mark.parametrize('a', (0.1, 0.2, 0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
+@pytest.mark.parametrize('a', (0.1, 0.2, 0.25, 0.5))
 def test_projgauss_mid_a(a):
     if a < 0.25:
         u = np.array([0.01, 0.1, 1]) / a

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -22,7 +22,7 @@ def test_against_hankel(model, kwargs):
     assert np.allclose(anl, num, rtol=1e-8)
 
 
-@pytest.mark.parametrize('a', (0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
+@pytest.mark.parametrize('a', (0.1, 0.25, 0.5))  # 0.2 doesn't seem to work for u=10, 100 (numerical or analytic)
 def test_projgauss_mid_a(a):
     u = np.array([0.1, 1, 10, 100])
 

--- a/analytic_diffuse/tests/test_against_integrators.py
+++ b/analytic_diffuse/tests/test_against_integrators.py
@@ -18,3 +18,13 @@ def test_against_hankel(model, kwargs):
     num = integrators.hankel_solver(model, u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8),  **kwargs)[0]
 
     assert np.allclose(anl, num, rtol=1e-8)
+
+
+@pytest.mark.parametrize('a', (0.2, 0.25, 0.5))
+def test_projgauss_mid_a(a):
+    u = np.array([0.1, 1, 10, 100])
+
+    anl = get_solution('projgauss')(u, a=a)
+    num = integrators.hankel_solver('projgauss', u, quad_kwargs=dict(epsabs=0, limit=100, epsrel=1e-8),  a=a)[0]
+
+    assert np.allclose(anl, num, rtol=1e-8)

--- a/analytic_diffuse/tests/test_solutions.py
+++ b/analytic_diffuse/tests/test_solutions.py
@@ -1,0 +1,35 @@
+from analytic_diffuse.solutions import projgauss
+import numpy as np
+
+
+def test_return_cumsum():
+    res = projgauss(1, 0.01, order=30, ret_cumsum=True)
+    assert res.shape == (30, )
+
+    res = projgauss(1, 0.01, order=30, ret_cumsum=False)
+    assert np.isscalar(res)
+
+    res = projgauss(np.linspace(1,2, 10), 0.01, order=30, ret_cumsum=True)
+    assert res.shape == (10, 30)
+
+    res = projgauss(np.linspace(1,2, 10), 0.01, order=30, ret_cumsum=False)
+    assert res.shape == (10, )
+
+
+def test_chunking():
+    res = projgauss(1, 0.01, order=30)
+    res2 = projgauss(1, 0.01, order=30, chunk_order=30)
+    assert res == res2
+
+    res3= projgauss(1, 0.01, order=30, chunk_order=15, ret_cumsum=True)
+    assert np.isclose(res3[-1], res2)
+    assert res3.shape[0] <= 30  # could be smaller, since it may converge.
+
+    res4 = projgauss(1, 0.01, chunk_order=10, ret_cumsum=True)
+    assert np.isclose(res4[-1], res3[-1])
+    assert res4.shape[0] <= 100  # default maximum order.
+
+    res5 = projgauss(1, 0.01, chunk_order=1, ret_cumsum=True)
+    assert np.isclose(res5[-1], res4[-1])
+    assert res5.shape[0] <= res4.shape[0]   # convergence should be stable.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+mpmath

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 mpmath
+pytest


### PR DESCRIPTION
Adds the following (from memory):

* requirements file
* allow the user to pass just theta for circularly symmetric models.
* Allow passing of scalar theta, phi
* Added an integrator for the hankel integral:
  - Can do high-precision (mpmath) or normal quadrature (scipy)
* Added tests for all circularly symmetric models, tested to 1e-8 relative tolerance to the adaptive quadrature.
* Added ability to have convergence in the sums
* Added ability to generate the cumulative sum for appropriate solutions

A couple of things:

* It's weird that we're labelling (az, zen) (phi, theta) in this code, but (theta, phi) in the paper.
* Tests for Projected Gaussian aren't working for a=0.2. I'm not sure if it's the analytic or numerical results that are wrong. They come good for a>=0.25 though. 