### PR TITLE
Update divide by zero warning filtering for numpy changes

### DIFF
--- a/analytic_diffuse/solutions.py
+++ b/analytic_diffuse/solutions.py
@@ -116,6 +116,8 @@ def _jinc(n, x):
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=RuntimeWarning,
                                 message="invalid value encountered in true_divide")
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message="invalid value encountered in divide")
         res = jv(n, x) / x
         res[x == 0] = 1 / 2
     return res
@@ -170,6 +172,8 @@ def polydome(uvecs: [float, np.ndarray], n: int=2) -> [float, np.ndarray]:
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=RuntimeWarning,
                                 message="invalid value encountered in true_divide")
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message="invalid value encountered in divide")
         if n == 2:
             res = (cosza_soln - (jv(2, 2 * np.pi * uamps)
                     - np.pi * uamps * jv(3, 2 * np.pi * uamps))  / (np.pi * uamps**2))


### PR DESCRIPTION
We're seeing warnings creeping through in pyuvsim because the warning message has changed from warning about a "true_divide" to just warning about a "divide". I haven't identified the numpy version where it changed in the numpy changelog (I tried), but empirically it changed between numpy versions 1.22.3 and 1.23. I just added another filter to make it work for newer versions as well as older ones.